### PR TITLE
Fix default spelling mistake

### DIFF
--- a/src/components/ScrollMarker.js
+++ b/src/components/ScrollMarker.js
@@ -52,7 +52,7 @@ export default {
     },
     visible: {
       type: Boolean,
-      defualt: () => false
+      default: () => false
     },
     spacing: {
       type: Number,


### PR DESCRIPTION
Fixes the VueJS warning "[Vue warn]: Invalid key "defualt" in validation rules object for prop "visible"."