### PR TITLE
Added comments to show $scrollview usage in applications

### DIFF
--- a/examples/src/components/pages/Home.vue
+++ b/examples/src/components/pages/Home.vue
@@ -13,6 +13,7 @@
 </template>
 
 <script>
+// import { $scrollview } from 'vue-scrollview'
 import { $scrollview } from '../../../../src'
 
 export default {

--- a/examples/src/components/pages/infinitescroll/InfiniteScroll.vue
+++ b/examples/src/components/pages/infinitescroll/InfiniteScroll.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script>
+// import { $scrollview } from 'vue-scrollview'
 import { $scrollview } from '../../../../../src'
 import ExampleStart from '../../ExampleStart'
 import ScrollImage from './ScrollImage'

--- a/examples/src/components/pages/lazyload/LazyLoad.vue
+++ b/examples/src/components/pages/lazyload/LazyLoad.vue
@@ -23,6 +23,7 @@
 </template>
 
 <script>
+// import { $scrollview } from 'vue-scrollview'
 import { $scrollview } from '../../../../../src'
 
 import ExampleStart from '.././../ExampleStart'

--- a/examples/src/components/pages/scrollmarkers/ScrollMarkers.vue
+++ b/examples/src/components/pages/scrollmarkers/ScrollMarkers.vue
@@ -64,6 +64,7 @@
 </template>
 
 <script>
+// import { $scrollview } from 'vue-scrollview'
 import { $scrollview } from '../../../../../src'
 import ExampleStart from '.././../ExampleStart'
 

--- a/examples/src/components/pages/scrollspy/Scrollspy.vue
+++ b/examples/src/components/pages/scrollspy/Scrollspy.vue
@@ -47,6 +47,7 @@
 </template>
 
 <script>
+// import { $scrollview } from 'vue-scrollview'
 import { $scrollview } from '../../../../../src'
 
 import menu from './menu.js'

--- a/examples/src/components/pages/test/Test.vue
+++ b/examples/src/components/pages/test/Test.vue
@@ -22,6 +22,7 @@
 </template>
 
 <script>
+// import { $scrollview } from 'vue-scrollview'
 import { $scrollview } from '../../../../../src'
 import VisibilityMarker from './VisibilityMarker'
 


### PR DESCRIPTION
I was working on an infinite scroll list component today and I could not figure out where to import the `$scrollview` variable from to use in my view component.

After reading the documentation, I found the way, but I implement many things by tweaking the code from provided examples (which are meant to be working out of the box) and I think it would be cool to include a hint in them as well on how to use the plugin in a real application, just to prevent people from having to search through the documentation.

I couldn't decide whether I should've added more context to my comments, so if that is an issue, I can make some further tweaks.

I think this kind of hint would help me but I do not know what is your opinion on the whole thing, so I am leaving it up to you to decide whether this addition is useful or not.